### PR TITLE
COCO constructor reads bytes RLE `counts` as an empty mask

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -164,3 +164,8 @@ docs/notes/
 
 # Generated reports
 report.pdf
+
+# Session working notes (PR bodies, review write-ups) — same rationale as
+# `plans/`: short half-life, not documentation anyone should find in the repo.
+/.reports/
+/.temp/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
+- **RLE `counts` as `bytes` loads correctly.** `mask.encode()` returns `counts`
+  as a `bytes` object, matching pycocotools, but the dataset loader decoded only
+  the `str` form. A `bytes` object is a Python sequence of ints, so it extracted
+  as a list of run lengths and became an uncompressed RLE holding the compressed
+  string's byte values — a mask that decodes to nothing. Nothing raised, so the
+  failure surfaced as segmentation AP of exactly `0.000`. `bytes` is now accepted
+  wherever a `segmentation` dict is parsed, in the `COCO` constructor and in
+  `load_res()` alike, and a `counts` value that is not `str`, `bytes`, or a list
+  of ints raises `TypeError` naming the type it got instead of producing an empty
+  mask.
+
 ## [1.0.0] - 2026-09-02
 
 ### Added

--- a/crates/hotcoco-pyo3/src/convert.rs
+++ b/crates/hotcoco-pyo3/src/convert.rs
@@ -222,10 +222,32 @@ fn py_to_segmentation(obj: &Bound<'_, PyAny>) -> PyResult<Segmentation> {
         let counts_obj = dict
             .get_item("counts")?
             .ok_or_else(|| pyo3::exceptions::PyValueError::new_err("dict missing 'counts'"))?;
+        // Try str first, then bytes (what `mask.encode` returns, matching
+        // pycocotools), then a list of ints (uncompressed RLE). Bytes must be
+        // checked before the list: a `bytes` object is a Python sequence of
+        // ints, so `extract::<Vec<u32>>()` succeeds on it and silently turns
+        // the compressed string's byte values into an uncompressed RLE.
         if let Ok(s) = counts_obj.extract::<String>() {
             return Ok(Segmentation::CompressedRle { size, counts: s });
         }
-        let counts: Vec<u32> = counts_obj.extract()?;
+        if let Ok(b) = counts_obj.cast::<PyBytes>() {
+            let s = std::str::from_utf8(b.as_bytes()).map_err(|e| {
+                pyo3::exceptions::PyValueError::new_err(format!("invalid UTF-8 in RLE counts: {e}"))
+            })?;
+            return Ok(Segmentation::CompressedRle {
+                size,
+                counts: s.to_string(),
+            });
+        }
+        let counts: Vec<u32> = counts_obj.extract().map_err(|_| {
+            let name = counts_obj
+                .get_type()
+                .name()
+                .map_or_else(|_| "?".to_string(), |n| n.to_string());
+            pyo3::exceptions::PyTypeError::new_err(format!(
+                "RLE 'counts' must be str, bytes, or a list of ints, got {name}"
+            ))
+        })?;
         return Ok(Segmentation::UncompressedRle { size, counts });
     }
     // Otherwise it's a polygon (list of lists)

--- a/docs/guide/masks.md
+++ b/docs/guide/masks.md
@@ -73,16 +73,18 @@ An RLE dict looks like:
 ## RLE `counts` is bytes, not a string
 
 `mask.encode()` returns `counts` as a `bytes` object, matching pycocotools.
-`load_res()` accepts either form in memory, but JSON cannot hold bytes — when
-writing RLE dicts into a COCO JSON file yourself, convert first:
+Every hotcoco entry point that reads a `segmentation` dict — the `COCO`
+constructor and `load_res()` — accepts `bytes`, `str`, or a list of run lengths,
+so an RLE from `mask.encode()` goes straight in. The same holds for dicts from
+third-party mask libraries, including pycocotools itself.
+
+JSON cannot hold bytes, though. When writing RLE dicts into a COCO JSON file
+yourself, convert first:
 
 ```python
 if isinstance(rle["counts"], bytes):
     rle["counts"] = rle["counts"].decode("utf-8")
 ```
-
-Some third-party mask libraries, such as older versions of pycocotools, also
-return `bytes`. Apply the same fix before passing those dicts to hotcoco.
 
 ## Area and bounding box
 

--- a/scripts/test_parity.py
+++ b/scripts/test_parity.py
@@ -15,9 +15,10 @@ from __future__ import annotations
 
 import warnings
 
+import numpy as np
 import pytest
 from helpers import COCO_KEYPOINT_NAMES, COCO_SKELETON, assert_metrics_match, run_both, suppress_output, written_json
-from hotcoco import COCO, COCOeval, Hierarchy
+from hotcoco import COCO, COCOeval, Hierarchy, mask
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -265,6 +266,80 @@ def test_segm_polygon_rasterization():
     ]
     py_stats, rs_stats, _ = run_both(gt, dts, "segm")
     assert_metrics_match(py_stats, rs_stats, "segm")
+
+
+def _bytes_rle():
+    """An RLE with ``counts`` as bytes, exactly what ``mask.encode`` returns."""
+    m = np.zeros((10, 10), dtype=np.uint8)
+    m[2:5, 2:5] = 1
+    rle = mask.encode(np.asfortranarray(m))
+    assert isinstance(rle["counts"], bytes)
+    return rle
+
+
+def _dataset_with_segmentation(segmentation):
+    return {
+        "images": [{"id": 1, "height": 10, "width": 10, "file_name": "test.jpg"}],
+        "annotations": [
+            {
+                "id": 1,
+                "image_id": 1,
+                "category_id": 1,
+                "bbox": [2.0, 2.0, 3.0, 3.0],
+                "area": 9.0,
+                "iscrowd": 0,
+                "segmentation": segmentation,
+            }
+        ],
+        "categories": [{"id": 1, "name": "cat", "supercategory": "none"}],
+    }
+
+
+def test_bytes_rle_round_trips_through_coco():
+    """encode() -> COCO() -> load_anns() -> decode() keeps the mask.
+
+    `mask.encode` returns `counts` as bytes (pycocotools' format). A `bytes`
+    object is a Python sequence of ints, so extracting it as a list of counts
+    succeeds and silently produces a garbage uncompressed RLE instead of
+    raising — the failure surfaced as segmentation AP of exactly 0.000.
+    """
+    rle = _bytes_rle()
+    coco = COCO(_dataset_with_segmentation(rle))
+    loaded = coco.load_anns([1])[0]["segmentation"]
+    assert mask.decode(loaded).sum() == 9
+
+
+def test_bytes_rle_round_trips_through_load_res():
+    """The same path for detections, which is how mask consumers evaluate."""
+    rle = _bytes_rle()
+    coco = COCO(_dataset_with_segmentation(rle))
+    # No bbox, so `load_res` treats the results as segm and derives area from
+    # the mask — a wrong parse shows up as a wrong area, not only a wrong mask.
+    dt = coco.load_res([{"image_id": 1, "category_id": 1, "score": 0.9, "segmentation": rle}])
+    ann = dt.load_anns(dt.get_ann_ids())[0]
+    assert mask.decode(ann["segmentation"]).sum() == 9
+    assert ann["area"] == 9.0
+
+
+def test_every_counts_form_agrees():
+    """bytes, str, and an uncompressed list of ints must all load the same mask."""
+    rle = _bytes_rle()
+    as_str = {"size": rle["size"], "counts": rle["counts"].decode("ascii")}
+    # Column-major runs for a 3x3 block at rows 2-4, cols 2-4 of a 10x10 mask.
+    as_list = {"size": [10, 10], "counts": [22, 3, 7, 3, 7, 3, 55]}
+    decoded = [
+        mask.decode(COCO(_dataset_with_segmentation(seg)).load_anns([1])[0]["segmentation"])
+        for seg in (rle, as_str, as_list)
+    ]
+    assert decoded[0].sum() == 9
+    assert (decoded[0] == decoded[1]).all()
+    assert (decoded[0] == decoded[2]).all()
+
+
+def test_unsupported_counts_type_raises():
+    """Anything that is not str, bytes, or a list of ints is an error, not an empty mask."""
+    with pytest.raises(TypeError, match="counts"):
+        COCO(_dataset_with_segmentation({"size": [10, 10], "counts": 3.5}))
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Description

`hotcoco.mask.encode` returns an RLE whose `counts` is `bytes`, matching pycocotools. The `COCO` constructor decoded only the `str` form. A `bytes` object is a Python sequence of ints, so `counts_obj.extract::<Vec<u32>>()` succeeded on it and turned the compressed string's byte values into an uncompressed RLE:

```
encoded: {'size': [10, 10], 'counts': b'f037000`1'}
loaded:  {'size': [10, 10], 'counts': [102, 48, 51, 55, 48, 48, 48, 96, 49]}
sum: 0
```

A round-trip through the package's own encoder and its own loader silently lost every mask.

**Impact.** Nothing raised, so the failure surfaced as segmentation AP of exactly `0.000` — which reads as a broken model, not a format mismatch. Any consumer evaluating masks was affected, including TorchMetrics. Both entry points were on the same path: the `COCO` constructor and `load_res()` share the `py_to_annotation` funnel, so detections were hit as well as ground truth. The 1.0 third-party-consumer smoke test did not cover it, because it evaluates boxes only.

**How it was resolved.** In `py_to_segmentation` (`crates/hotcoco-pyo3/src/convert.rs`):

- A `PyBytes` branch now sits between the `str` try and the list-of-ints try. Order is the whole bug: bytes must be checked before the sequence extract. The payload is ASCII by construction, so it decodes as UTF-8 into `CompressedRle`.
- A `counts` value that is not `str`, `bytes`, or a list of ints now raises `TypeError: RLE 'counts' must be str, bytes, or a list of ints, got float`, instead of the unhelpful `'float' object is not an instance of 'Sequence'`.

The root cause was two `counts` parsers that had drifted: `py_to_rle`, which the `mask` module uses, already accepted bytes; `py_to_segmentation`, which the dataset loader uses, did not. The new branch mirrors `py_to_rle`, including its error text.

**How it was verified.** Four regression tests in `scripts/test_parity.py`:

- `test_bytes_rle_round_trips_through_coco` — the reported repro: encode, load through `COCO`, decode, assert the area equals the source area.
- `test_bytes_rle_round_trips_through_load_res` — the same round-trip through detection results. The result dict carries no `bbox`, so `load_res()` derives area from the mask and a wrong parse shows up as a wrong area, not only a wrong mask.
- `test_every_counts_form_agrees` — bytes, str, and an uncompressed list of ints all decode to the same mask.
- `test_unsupported_counts_type_raises` — a float `counts` raises rather than producing an empty mask.

All four fail on a build of the unfixed code and pass after the fix, so the tests are known to detect the defect they cover.

`docs/guide/masks.md` documented the workaround for this bug — it told readers to decode `bytes` before passing dicts to hotcoco. That section now states which forms the loaders accept, and keeps the decode step only for its real constraint: writing RLE dicts into a COCO JSON file.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [x] Documentation
- [ ] Other:

## Checklist

- [x] `cargo fmt --all` applied
- [x] `cargo clippy --workspace --all-targets -- -D warnings` passes
- [x] `cargo test` passes — 9 suites, 0 failed, 1 ignored
- [x] If eval logic changed: parity verified with `just parity` (output below) — eval logic did not change, so `just parity` does not apply; see below for the gate that does cover this code
- [x] `CHANGELOG.md` updated under `[Unreleased]`
- [x] README / docs updated if public API changed

`pytest scripts/test_parity.py scripts/test_stubs.py scripts/test_theme.py scripts/test_cli.py`: 83 passed. `scripts/check_docs_links.py`: 29 pages, all internal links, anchors, and nav entries resolve.

## Parity output (if applicable)

This is a parse-layer change, not evaluation logic, so `just parity` is not the applicable gate — and it would not exercise the defect in any case, since it loads from JSON, where `counts` is always `str`. The gate that does cover this code is the mask codec differential against pycocotools, `just parity-mask`:

```
====================================================================
  hotcoco.mask vs pycocotools.mask — 400 cases, seed 42
====================================================================

  ALL MASK OPERATIONS MATCH  (400 cases)
```
