### PR TITLE
Accept `bool` masks in `mask.encode`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
+- **`mask.encode` accepts `bool` masks.** Any one-byte integer or boolean dtype
+  is viewed as `uint8` instead of rejected, so the arrays torch-side code stores
+  (TorchMetrics keeps masks as `bool`) encode without a cast. A wider dtype, or a
+  non-array input, now raises a `TypeError` naming the dtype and the fix rather
+  than `'ndarray' object is not an instance of 'ndarray'`.
+
 ## [1.0.0] - 2026-09-02
 
 ### Added

--- a/crates/hotcoco-pyo3/src/mask.rs
+++ b/crates/hotcoco-pyo3/src/mask.rs
@@ -43,6 +43,65 @@ fn extract_rle_list(obj: &Bound<'_, PyAny>) -> PyResult<Vec<hotcoco_core::Rle>> 
 // encode
 // ---------------------------------------------------------------------------
 
+/// View a mask array as `uint8`, or explain why it cannot be one.
+///
+/// Deliberate deviation: `pycocotools.mask.encode` takes `uint8` only and
+/// raises on anything else. Every torch-side consumer stores masks as `bool`
+/// (TorchMetrics does), so a `bool` array reaching the drop-in path is the
+/// common case, not a mistake. Any single-byte integer or boolean dtype is
+/// viewed as `uint8` — a zero-copy relabel that keeps the shape, strides, and
+/// `f_contiguous` flag the encode paths read. Wider dtypes are still an error,
+/// but one that names the dtype and the fix.
+fn view_as_uint8<'py>(mask: &Bound<'py, PyAny>) -> PyResult<Bound<'py, PyAny>> {
+    // A list has no `dtype` and a torch tensor's `dtype` has no `kind`; both
+    // become the same type error rather than surfacing as an AttributeError
+    // from whichever attribute happened to be missing.
+    let Ok((kind, itemsize)) = numpy_dtype_of(mask) else {
+        return Err(not_a_mask_array(&type_name_of(mask)));
+    };
+
+    if kind == "u" && itemsize == 1 {
+        return Ok(mask.clone());
+    }
+    // 'b' is numpy's boolean kind, 'i' its signed integers. Either is one byte
+    // wide only for `bool` and `int8`, and `encode` counts every nonzero value
+    // as foreground, so a negative `int8` is foreground like any other nonzero.
+    if (kind == "b" || kind == "i") && itemsize == 1 {
+        return mask.call_method1("view", ("uint8",));
+    }
+
+    let name: String = mask
+        .getattr("dtype")
+        .and_then(|d| d.getattr("name"))
+        .and_then(|n| n.extract())
+        .unwrap_or_else(|_| format!("itemsize {itemsize}"));
+    Err(PyErr::new::<pyo3::exceptions::PyTypeError, _>(format!(
+        "encode(): mask must be a numpy array with dtype uint8 or bool, got {name}; \
+         cast it with mask.astype(numpy.uint8)"
+    )))
+}
+
+/// The `(kind, itemsize)` pair of a numpy dtype, or an error for anything else.
+fn numpy_dtype_of(obj: &Bound<'_, PyAny>) -> PyResult<(String, usize)> {
+    let dtype = obj.getattr("dtype")?;
+    Ok((
+        dtype.getattr("kind")?.extract()?,
+        dtype.getattr("itemsize")?.extract()?,
+    ))
+}
+
+fn not_a_mask_array(type_name: &str) -> PyErr {
+    PyErr::new::<pyo3::exceptions::PyTypeError, _>(format!(
+        "encode(): mask must be a numpy array with dtype uint8 or bool, got {type_name}"
+    ))
+}
+
+fn type_name_of(obj: &Bound<'_, PyAny>) -> String {
+    obj.get_type()
+        .name()
+        .map_or_else(|_| "unknown type".to_string(), |n| n.to_string())
+}
+
 /// Encode a binary mask to RLE in pycocotools format.
 ///
 /// Parameters
@@ -50,7 +109,8 @@ fn extract_rle_list(obj: &Bound<'_, PyAny>) -> PyResult<Vec<hotcoco_core::Rle>> 
 /// mask : numpy.ndarray
 ///     2-D ``(H, W)`` → returns a single RLE dict.
 ///     3-D ``(H, W, N)`` → returns a list of *N* RLE dicts.
-///     Accepts both Fortran-order (pycocotools convention) and C-order arrays.
+///     Accepts both Fortran-order (pycocotools convention) and C-order arrays,
+///     and both ``uint8`` and ``bool`` dtypes.
 ///
 /// Returns
 /// -------
@@ -59,6 +119,7 @@ fn extract_rle_list(obj: &Bound<'_, PyAny>) -> PyResult<Vec<hotcoco_core::Rle>> 
 #[pyfunction]
 #[pyo3(text_signature = "(mask)")]
 pub fn encode(py: Python<'_>, mask: &Bound<'_, PyAny>) -> PyResult<Py<PyAny>> {
+    let mask = &view_as_uint8(mask)?;
     let ndim: usize = mask.getattr("ndim")?.extract()?;
     match ndim {
         2 => encode_2d(py, mask),

--- a/docs/api/mask.md
+++ b/docs/api/mask.md
@@ -43,7 +43,7 @@ Encode a binary mask to RLE.
 
     | Parameter | Type | Description |
     |-----------|------|-------------|
-    | `mask` | `numpy.ndarray` | 2-D `(H, W)` or 3-D `(H, W, N)`, dtype `uint8` |
+    | `mask` | `numpy.ndarray` | 2-D `(H, W)` or 3-D `(H, W, N)`, dtype `uint8` or `bool` |
 
     **Returns:**
 
@@ -54,6 +54,10 @@ Encode a binary mask to RLE.
     rle = mask.encode(m)   # m: (H, W) uint8 array
     # {"size": [100, 100], "counts": b"..."}
     ```
+
+    `bool` masks are accepted as well as `uint8`, which pycocotools does not do:
+    torch-side code stores masks as `bool`, so requiring a cast would break the
+    drop-in path for no gain. Wider dtypes raise a `TypeError` naming the dtype.
 
 === "Rust"
 

--- a/docs/guide/masks.md
+++ b/docs/guide/masks.md
@@ -50,6 +50,11 @@ An RLE dict looks like:
     m_c = np.zeros((100, 100), dtype=np.uint8)
     m_c[10:50, 20:80] = 1
     rle = mask.encode(m_c)  # same result
+
+    # bool masks encode too — what torch-side code (TorchMetrics) produces
+    m_bool = np.zeros((100, 100), dtype=bool, order="F")
+    m_bool[10:50, 20:80] = True
+    rle = mask.encode(m_bool)  # same result, no cast needed
     ```
 
 === "Rust"

--- a/python/hotcoco/mask.pyi
+++ b/python/hotcoco/mask.pyi
@@ -15,13 +15,15 @@ import numpy.typing as npt
 
 _Rle = dict[str, Any]
 
+_MaskDtype = np.dtype[np.uint8] | np.dtype[np.bool_]
+
 @overload
-def encode(mask: np.ndarray[tuple[int, int], np.dtype[np.uint8]]) -> _Rle:
+def encode(mask: np.ndarray[tuple[int, int], _MaskDtype]) -> _Rle:
     """Encode a 2-D ``(H, W)`` binary mask to a single RLE dict."""
     ...
 
 @overload
-def encode(mask: np.ndarray[tuple[int, int, int], np.dtype[np.uint8]]) -> list[_Rle]:
+def encode(mask: np.ndarray[tuple[int, int, int], _MaskDtype]) -> list[_Rle]:
     """Encode a 3-D ``(H, W, N)`` mask stack to a list of N RLE dicts."""
     ...
 

--- a/scripts/test_parity.py
+++ b/scripts/test_parity.py
@@ -15,9 +15,10 @@ from __future__ import annotations
 
 import warnings
 
+import numpy as np
 import pytest
 from helpers import COCO_KEYPOINT_NAMES, COCO_SKELETON, assert_metrics_match, run_both, suppress_output, written_json
-from hotcoco import COCO, COCOeval, Hierarchy
+from hotcoco import COCO, COCOeval, Hierarchy, mask
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -719,3 +720,44 @@ def test_non_reference_params_warn_and_downgrade_provenance():
     assert any("rec_thrs" in m for m in messages), f"expected a rec_thrs warning catchable from Python, got {messages}"
     # Provenance has to survive into the archived artifact, not just the report.
     assert off.results()["provenance"] == "extension"
+
+
+# ---------------------------------------------------------------------------
+# mask.encode dtypes
+# ---------------------------------------------------------------------------
+
+
+def test_encode_accepts_bool_masks():
+    """A `bool` mask encodes to the same RLE as its `uint8` twin.
+
+    pycocotools takes `uint8` only, but every torch-side consumer stores masks
+    as `bool` -- TorchMetrics does -- so `bool` reaching the drop-in path is the
+    common case, not a mistake.
+    """
+    m = np.zeros((10, 10), dtype=bool)
+    m[2:5, 2:5] = True
+
+    for arr in (m, np.asfortranarray(m)):
+        assert mask.encode(arr) == mask.encode(arr.astype(np.uint8))
+
+
+def test_encode_accepts_bool_mask_stacks():
+    """The reported repro: a 3-D `(H, W, N)` Fortran-order `bool` stack."""
+    m = np.zeros((10, 10, 1), dtype=bool)
+    m[2:5, 2:5, 0] = True
+    stack = np.asfortranarray(m)
+
+    assert mask.encode(stack) == mask.encode(stack.astype(np.uint8))
+
+
+def test_encode_rejects_wide_dtypes_with_a_readable_message():
+    """A dtype that is not one byte wide is an error naming the dtype and the fix.
+
+    The message is the point: the old failure was `'ndarray' object is not an
+    instance of 'ndarray'`, which names neither the dtype nor the argument.
+    """
+    with pytest.raises(TypeError, match=r"float32.*astype"):
+        mask.encode(np.zeros((10, 10), dtype=np.float32))
+
+    with pytest.raises(TypeError, match=r"mask must be a numpy array"):
+        mask.encode([[0, 1], [1, 0]])


### PR DESCRIPTION
## Description

`hotcoco.mask.encode` accepted `uint8` arrays only. Any other dtype failed inside the PyO3 extraction with a message that named neither the dtype nor the argument:

```python
hotcoco.mask.encode(np.asfortranarray(np.zeros((10, 10, 1), dtype=bool)))
# TypeError: 'ndarray' object is not an instance of 'ndarray'
```

This PR normalizes the dtype at the entry point. `uint8` passes through unchanged; any other one-byte boolean or integer dtype (`bool`, `int8`) is viewed as `uint8`, which is a zero-copy relabel that preserves shape, strides, and the `f_contiguous` flag that the 2-D and 3-D encode paths read. Wider dtypes, and inputs that are not numpy arrays at all, now raise a `TypeError` that names the dtype and the fix.

## Impact

- Masks stored as `bool` — what TorchMetrics and most torch-side code produce — encode without an explicit `astype` call, so the `pycocotools` drop-in path works for mask evaluation out of the box.
- Failures that remain are diagnosable without reading the binding source:

  ```
  TypeError: encode(): mask must be a numpy array with dtype uint8 or bool, got float32; cast it with mask.astype(numpy.uint8)
  ```

  A list, or a torch tensor passed by mistake, gets the same error naming its type rather than an `AttributeError` about `ndim`.
- Deliberate deviation from pycocotools, which rejects everything but `uint8`. It is strictly more permissive: no previously accepted input changes behavior, and encoded RLE output is byte-identical to the `uint8` equivalent.
- No effect on evaluation metrics. The change is confined to the Python binding for `mask.encode`; the Rust kernel and every evaluation path are untouched.

## How it was resolved

| File | Change |
|---|---|
| `crates/hotcoco-pyo3/src/mask.rs` | `view_as_uint8()` runs before the ndim dispatch: `uint8` passes through, one-byte `bool`/`int8` is viewed as `uint8`, anything else raises a `TypeError` naming the dtype and the cast |
| `python/hotcoco/mask.pyi` | Both `encode` overloads take `_MaskDtype`, a `np.dtype[np.uint8] \| np.dtype[np.bool_]` union |
| `scripts/test_parity.py` | Three regression tests (below) |
| `docs/api/mask.md`, `docs/guide/masks.md` | Parameter table, a note on the deviation, and a `bool` example |
| `CHANGELOG.md` | Entry under `[Unreleased]` → Fixed |

The core encoder already treated any nonzero value as foreground, so a negative `int8` is foreground like any other nonzero — no change was needed in `crates/hotcoco/src/mask.rs`.

Scope was kept to `encode`. `frPyObjects` and the other array entry points are unchanged.

## How it was verified

Tests added in `scripts/test_parity.py`:

- `test_encode_accepts_bool_masks` — a 2-D `bool` mask, in both C and Fortran order, encodes to the same RLE as its `uint8` twin.
- `test_encode_accepts_bool_mask_stacks` — the reported repro, a 3-D `(10, 10, 1)` Fortran-order `bool` stack.
- `test_encode_rejects_wide_dtypes_with_a_readable_message` — `float32` and a plain list raise `TypeError`, asserted with `pytest.raises(..., match=...)` on the message text. The `match=` is what makes the test discriminating: a bare `pytest.raises(TypeError)` would have passed against the old behavior too.

The guard was proven to fail before it was trusted, per the repo's "verifying a check can fail" rule: reverting `crates/hotcoco-pyo3/src/mask.rs` to `HEAD` and rebuilding made all three new tests fail; restoring the fix made them pass.

Suites run locally:

- `cargo fmt --all --check` — clean
- `cargo clippy --workspace --all-targets -- -D warnings` — passes
- `cargo test` — 175 + 20 + 10 + the remaining integration binaries, 0 failed
- `uv run pytest scripts/test_parity.py scripts/test_stubs.py` — 55 passed
- `uv run python scripts/parity_mask.py` — 400 cases match `pycocotools.mask`
- `uv run python scripts/check_docs_links.py` — 29 pages, all links, anchors, and nav entries resolve
- `pyright` 1.1.413 (via `uvx`; not installed in the project venv) — 0 errors, plus the pre-existing `reportMissingModuleSource` warning for the stub-only `mask` module

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Documentation
- [ ] Other:

## Checklist

- [x] `cargo fmt --all` applied
- [x] `cargo clippy --workspace --all-targets -- -D warnings` passes
- [x] `cargo test` passes
- [ ] If eval logic changed: parity verified with `just parity` (output below) — N/A, no evaluation logic changed; `scripts/parity_mask.py` was run instead and is quoted below
- [x] `CHANGELOG.md` updated under `[Unreleased]`
- [x] README / docs updated if public API changed

## Parity output (if applicable)

`just parity` does not apply — this change does not touch evaluation logic, and it needs local COCO data under the gitignored `data/`. The mask parity script covers the changed surface:

```
$ uv run python scripts/parity_mask.py
====================================================================
  hotcoco.mask vs pycocotools.mask — 400 cases, seed 42
====================================================================

  ALL MASK OPERATIONS MATCH  (400 cases)
```

pycocotools cannot take `bool` input, so that side of the comparison stays `uint8`-only, which is correct: the parity claim is about encoded output, and `bool` input produces byte-identical RLE to its `uint8` twin (asserted by the new tests).
